### PR TITLE
Fix for issue #40

### DIFF
--- a/Migration.cfc
+++ b/Migration.cfc
@@ -188,7 +188,7 @@
 					} else if(IsDate(arguments[loc.key])) {
 						loc.columnValues = ListAppend(loc.columnValues,"#arguments[loc.key]#");
 					} else {
-						loc.columnValues = ListAppend(loc.columnValues,"'#ReplaceNoCase(#arguments[loc.key]#,"'","''")#'");
+						loc.columnValues = ListAppend(loc.columnValues,"'#ReplaceNoCase(arguments[loc.key],"'","''")#'");
 					}
 				}
 			}


### PR DESCRIPTION
Simple syntax error in Migration.cfc was causing the createObjectFromRoot to throw an exception. Fixed syntax error and migrations work again.
